### PR TITLE
Fix prettier action

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -8,6 +8,7 @@ jobs:
     name: Prettier
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - uses: actionsx/prettier@v2
         with:
           # prettier CLI arguments.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1739,9 +1739,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.1.tgz",
+      "integrity": "sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw==",
       "dev": true
     },
     "process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@typescript-eslint/eslint-plugin": "^3.10.1",
     "@typescript-eslint/parser": "^3.10.1",
     "eslint": "^7.7.0",
-    "prettier": "^1.19.1",
+    "prettier": "^2.1.1",
     "typescript": "^4.0.2"
   }
 }


### PR DESCRIPTION
Prettier is always failing. Let's switch to https://github.com/marketplace/actions/prettier-action in the hopes that it works better.
In addition, make sure subdirectories are checked when labeling.