### PR TITLE
Fixed issues in chats.ts

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -8,6 +8,7 @@ jobs:
     name: Prettier
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - uses: actionsx/prettier@v2
         with:
           # prettier CLI arguments.


### PR DESCRIPTION
If any of these weren't mistakes, leave a comment and I'll take them out of the commit.

- Add platform and classID to ChatResult
- Switch references to courses to be classes
- Remove references to sections
- Remove unused regexFail message
- Add a function to determine what platform a link is on based on DB values
- When creating or updating a chat, ensure a class exists with the given ID
- When creating or updating a chat, determine the platform
- Add missing comma that caused a syntax error, allowing Prettier to run